### PR TITLE
Update schema

### DIFF
--- a/hypermode.schema.json
+++ b/hypermode.schema.json
@@ -1,7 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/hypermode.json",
-  "additionalProperties": true,
+  "type": "object",
+  "additionalProperties": false,
   "properties": {
     "hosts": {
       "type": "array",
@@ -57,6 +58,5 @@
         }
       }
     }
-  },
-  "type": "object"
+  }
 }

--- a/hypermode.schema.json
+++ b/hypermode.schema.json
@@ -20,6 +20,11 @@
             "format": "uri",
             "description": "URL and base path for connections to the host.",
             "markdownDescription": "URL and base path for connections to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
+          },
+          "authHeader": {
+            "type": "string",
+            "description": "Authorization header name for connections to the host.",
+            "markdownDescription": "Authorization header name for connections to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
           }
         }
       }


### PR DESCRIPTION
- Add missing `authHeader` property
- Don't allow extra properties.  We want schema validation to fail if a property is undefined.