### PR TITLE
Validate fields

### DIFF
--- a/hypermode.schema.json
+++ b/hypermode.schema.json
@@ -19,17 +19,22 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?!-|.*-$|.*--)[a-zA-Z0-9-]+$",
             "description": "Internal name of your host. Used for indicating the host of a model or for a connection.",
             "markdownDescription": "Internal name of your host. Used for indicating the host of a model or for a connection.\n\nReference: https://docs.hypermode.com/define-hosts"
           },
           "endpoint": {
             "type": "string",
             "format": "uri",
+            "minLength": 1,
             "description": "URL and base path for connections to the host.",
             "markdownDescription": "URL and base path for connections to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
           },
           "authHeader": {
             "type": "string",
+            "minLength": 1,
             "description": "Authorization header name for connections to the host.",
             "markdownDescription": "Authorization header name for connections to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
           }
@@ -45,26 +50,35 @@
         "properties": {
           "host": {
             "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?!-|.*-$|.*--)[a-zA-Z0-9-]+$",
             "description": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host.",
             "markdownDescription": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host.\n\nReference: https://docs.hypermode.com/define-models"
           },
           "name": {
             "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^(?!-|.*-$|.*--)[a-zA-Z0-9-]+$",
             "description": "Internal name of your AI model. Used for indicating the model to use in an API call.",
             "markdownDescription": "Internal name of your AI model. Used for indicating the model to use in an API call.\n\nReference: https://docs.hypermode.com/define-models"
           },
           "provider": {
             "type": "string",
+            "minLength": 1,
             "description": "Source location of model, such as 'hugging-face' or 'openai'.",
             "markdownDescription": "Source location of model, such as 'hugging-face' or 'openai'.\n\nReference: https://docs.hypermode.com/define-models"
           },
           "sourceModel": {
             "type": "string",
+            "minLength": 1,
             "description": "Relative path of model within provider.",
             "markdownDescription": "Relative path of model within provider.\n\nReference: https://docs.hypermode.com/define-models"
           },
           "task": {
             "type": "string",
+            "minLength": 1,
             "description": "Training intent of model, such as 'classification' or 'embedding'.",
             "markdownDescription": "Training intent of model, such as 'classification' or 'embedding'.\n\nReference: https://docs.hypermode.com/define-models"
           }


### PR DESCRIPTION
Host and model name should be restricted to `A-Z`, `a-z`, `0-9` and the hyphen (`-`) character.  The should also not start with a hyphen, end with a hyphen, or have more than one consecutive hyphen.

Also set min/max lengths where appropriate.  Most fields should have min length 1 to avoid empty string (`""`) being considered valid.  Host and model names should have max length 63.